### PR TITLE
Handle veJoeStaking edge cases + minor cleanups

### DIFF
--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -179,6 +179,16 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
 
             uint256 userStakedJoe = userInfo.balance;
 
+            uint256 userVeJoeBalance = veJoe.balanceOf(_user);
+            uint256 userMaxVeJoeCap = userStakedJoe.mul(maxCap);
+
+            // If the user is currently at their max veJOE cap, we need to update
+            // their `lastRewardTimestamp` to now to prevent passive veJOE accrual
+            // after hitting their max cap.
+            if (userVeJoeBalance >= userMaxVeJoeCap) {
+                userInfo.lastRewardTimestamp = block.timestamp;
+            }
+
             userInfo.balance = userStakedJoe.add(_amount);
 
             // User is eligible for boosted benefits `_amount` is at least

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -179,7 +179,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
 
             uint256 userStakedJoe = userInfo.balance;
 
-            uint256 userVeJoeBalance = veJoe.balanceOf(_user);
+            uint256 userVeJoeBalance = veJoe.balanceOf(msg.sender);
             uint256 userMaxVeJoeCap = userStakedJoe.mul(maxCap);
 
             // If the user is currently at their max veJOE cap, we need to update

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -270,12 +270,18 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
                 // Proof by contradiction:
                 // 1. Assume that `user.boostEndTimestamp != 0` and
                 //    `user.boostEndTimestamp < user.lastRewardTimestamp`.
-                // 2. That means that at time `user.lastRewardTimestamp`, the user claimed
-                //    some veJOE. Furthermore, we know that anytime a user claims some veJOE,
-                //    if the current timestamp is greater than or equal to `user.boostEndTimestamp`,
-                //    we will update `user.boostEndTimestamp` to be `0` (see `_claim` method).
-                // 3. This means that `user.boostEndTimestamp` should be `0` but that contradicts our
-                //    assumption that `user.boostEndTimestamp != 0`
+                // 2. There are 3 cases when a user's `lastRewardTimestamp` is updated:
+                //    a. User claimed pending veJOE: We know that anytime a user claims some veJOE,
+                //       if the current timestamp is greater than or equal to `user.boostEndTimestamp`,
+                //       we will update `user.boostEndTimestamp` to be `0` (see `_claim` method). This
+                //       means that `user.boostEndTimestamp` should be `0` but that contradicts our
+                //       assumption that `user.boostEndTimestamp != 0`.
+                //    b. User JOE for the first time: When a user stakes JOE for the first time, we set
+                //       `user.lastRewardTimestamp` to `block.timestamp` and `user.boostEndTimestamp` to
+                //       `block.timestamp + boostedDuration`. This contradicts our assumption that
+                //       `user.boostEndTimestamp < user.lastRewardTimestamp`.
+                //    c. User unstaked JOE: Whenever a user unstakes JOE, we reset `user.boostEndTimestamp`
+                //       to be 0. This contradicts our assumption that `user.boostEndTimestamp != 0`.
                 // QED.
                 // With this, we now know `0 < user.lastRewardTimestamp <= user.boostEndTimestamp < block.timestamp`,
                 // which will allow us to perform the following logic safely.

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -283,12 +283,8 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
                 //    c. User unstaked JOE: Whenever a user unstakes JOE, we reset `user.boostEndTimestamp`
                 //       to be 0. This contradicts our assumption that `user.boostEndTimestamp != 0`.
                 // QED.
-                // With this, we now know `0 < user.lastRewardTimestamp <= user.boostEndTimestamp < block.timestamp`,
-                // which will allow us to perform the following logic safely.
 
-                // If the `block.timestamp > user.boostEndTimestamp` and `boostEndTimestamp != 0`,
-                // that means the user's boosted benefits ended sometime between their `lastRewardTimestamp`
-                // and now.
+                // Now we know that `0 < user.lastRewardTimestamp <= user.boostEndTimestamp < block.timestamp`.
                 // In this case, we need to properly provide them the boosted generation rate for
                 // those `boostEndTimestamp - lastRewardTimestamp` seconds.
                 uint256 boostedTimeElapsed = user.boostEndTimestamp.sub(user.lastRewardTimestamp);

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -184,7 +184,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
 
             // If the user is currently at their max veJOE cap, we need to update
             // their `lastRewardTimestamp` to now to prevent passive veJOE accrual
-            // after hitting their max cap.
+            // after user hit their max cap.
             if (userVeJoeBalance >= userMaxVeJoeCap) {
                 userInfo.lastRewardTimestamp = block.timestamp;
             }
@@ -286,7 +286,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
                 //       we will update `user.boostEndTimestamp` to be `0` (see `_claim` method). This
                 //       means that `user.boostEndTimestamp` should be `0` but that contradicts our
                 //       assumption that `user.boostEndTimestamp != 0`.
-                //    b. User JOE for the first time: When a user stakes JOE for the first time, we set
+                //    b. User stakes JOE for the first time: When a user stakes JOE for the first time, we set
                 //       `user.lastRewardTimestamp` to `block.timestamp` and `user.boostEndTimestamp` to
                 //       `block.timestamp + boostedDuration`. This contradicts our assumption that
                 //       `user.boostEndTimestamp < user.lastRewardTimestamp`.

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -377,6 +377,47 @@ describe("VeJoe Staking", function () {
         secondDepositBlock.timestamp + this.boostedDuration
       );
     });
+
+    it("should have lastRewardTimestamp updated after depositing if holding max veJOE cap", async function () {
+      await this.veJoeStaking
+        .connect(this.alice)
+        .deposit(ethers.utils.parseEther("100"));
+
+      // Increase by `maxCap` seconds to ensure that user will have max veJOE
+      // after claiming
+      await increase(this.maxCap);
+
+      await this.veJoeStaking.connect(this.alice).claim();
+
+      const claimBlock = await ethers.provider.getBlock();
+
+      const claimAliceUserInfo = await this.veJoeStaking.userInfos(
+        this.alice.address
+      );
+      // lastRewardTimestamp
+      expect(claimAliceUserInfo[1]).to.be.equal(claimBlock.timestamp);
+
+      await increase(this.maxCap);
+
+      const pendingVeJoe = await this.veJoeStaking.getPendingVeJoe(
+        this.alice.address
+      );
+      expect(pendingVeJoe).to.be.equal(0);
+
+      await this.veJoeStaking
+        .connect(this.alice)
+        .deposit(ethers.utils.parseEther("5"));
+
+      const secondDepositBlock = await ethers.provider.getBlock();
+
+      const secondDepositAliceUserInfo = await this.veJoeStaking.userInfos(
+        this.alice.address
+      );
+      // lastRewardTimestamp
+      expect(secondDepositAliceUserInfo[1]).to.be.equal(
+        secondDepositBlock.timestamp
+      );
+    });
   });
 
   describe("withdraw", function () {

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -295,18 +295,28 @@ describe("VeJoe Staking", function () {
         .connect(this.alice)
         .deposit(ethers.utils.parseEther("100"));
 
-      const block = await ethers.provider.getBlock();
+      await increase(this.boostedDuration);
+
+      await this.veJoeStaking.connect(this.alice).claim();
+
+      const afterClaimAliceUserInfo = await this.veJoeStaking.userInfos(
+        this.alice.address
+      );
+      // boostEndTimestamp
+      expect(afterClaimAliceUserInfo[2]).to.be.equal(0);
 
       await this.veJoeStaking
         .connect(this.alice)
         .deposit(ethers.utils.parseEther("5"));
 
-      const afterAliceUserInfo = await this.veJoeStaking.userInfos(
+      const secondDepositBlock = await ethers.provider.getBlock();
+
+      const seconDepositAliceUserInfo = await this.veJoeStaking.userInfos(
         this.alice.address
       );
       // boostEndTimestamp
-      expect(afterAliceUserInfo[2]).to.be.equal(
-        block.timestamp + this.boostedDuration
+      expect(seconDepositAliceUserInfo[2]).to.be.equal(
+        secondDepositBlock.timestamp + this.boostedDuration
       );
     });
 
@@ -326,6 +336,46 @@ describe("VeJoe Staking", function () {
       );
       // boostEndTimestamp
       expect(afterAliceUserInfo[2]).to.be.equal(0);
+    });
+
+    it("should have boosted period extended after depositing boostedThreshold and currently receiving boosted benefits", async function () {
+      await this.veJoeStaking
+        .connect(this.alice)
+        .deposit(ethers.utils.parseEther("100"));
+
+      const initialDepositBlock = await ethers.provider.getBlock();
+
+      const initialDepositAliceUserInfo = await this.veJoeStaking.userInfos(
+        this.alice.address
+      );
+      const initialDepositBoostEndTimestamp = initialDepositAliceUserInfo[2];
+
+      expect(initialDepositBoostEndTimestamp).to.be.equal(
+        initialDepositBlock.timestamp + this.boostedDuration
+      );
+
+      // Increase by some amount of time less than boostedDuration
+      await increase(this.boostedDuration / 2);
+
+      // Deposit boostedThreshold amount so that boost period gets extended
+      await this.veJoeStaking
+        .connect(this.alice)
+        .deposit(ethers.utils.parseEther("5"));
+
+      const secondDepositBlock = await ethers.provider.getBlock();
+
+      const secondDepositAliceUserInfo = await this.veJoeStaking.userInfos(
+        this.alice.address
+      );
+      // boostEndTimestamp
+      const secondDepositBoostEndTimestamp = secondDepositAliceUserInfo[2];
+
+      expect(
+        secondDepositBoostEndTimestamp.gt(initialDepositBoostEndTimestamp)
+      ).to.be.equal(true);
+      expect(secondDepositBoostEndTimestamp).to.be.equal(
+        secondDepositBlock.timestamp + this.boostedDuration
+      );
     });
   });
 


### PR DESCRIPTION
There are some edge cases in `VeJoeStaking` that I realized I didn't handle in my initial PR. Specifically:

1. When the user deposits `boostedThreshold` amount of `JOE`, we should extend their boost period **even if they are currently already receiving boosted benefits**.
2. We shouldn't allow passive accrual of veJOE after the user has hit their max veJOE cap. For example, imagine the following scenario:
  a. User has some amount of staked JOE and max veJOE cap.
  b. After `s` seconds, the user deposits some more JOE — this means that their max veJOE cap now increases! However, the user should not be accruing any veJOE for those `s` seconds where they were at their max veJOE cap. We can make sure of this by updating the user's `lastRewardTimestamp` inside `deposit` if they are at their max veJOE cap.

I've added tests as well for these two edge cases.