### PR TITLE
Add checks for certain variables in veJOE staking

### DIFF
--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -106,7 +106,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             _boostedThreshold != 0 && _boostedThreshold <= 100,
             "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
         );
-        require(_boostedDuration <= MAX_BOOSTED_DURATION, "VeJoeStaking: expected _boostedDuration to be <= 15 days");
+        require(_boostedDuration <= MAX_BOOSTED_DURATION, "VeJoeStaking: expected _boostedDuration to be <= 365 days");
         require(
             _maxCap != 0 && _maxCap <= MAX_MAX_CAP,
             "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
@@ -172,7 +172,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice Set boostedDuration
     /// @param _boostedDuration The new boostedDuration
     function setBoostedDuration(uint256 _boostedDuration) external onlyOwner {
-        require(_boostedDuration <= MAX_BOOSTED_DURATION, "VeJoeStaking: expected _boostedDuration to be <= 15 days");
+        require(_boostedDuration <= MAX_BOOSTED_DURATION, "VeJoeStaking: expected _boostedDuration to be <= 365 days");
         boostedDuration = _boostedDuration;
         emit UpdateBoostedDuration(msg.sender, _boostedDuration);
     }

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -42,7 +42,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     uint256 public maxCap;
 
     /// @notice The upper limit of `maxCap`
-    uint256 public MAX_MAX_CAP;
+    uint256 public UPPER_LIMIT_MAX_CAP;
 
     /// @notice Rate of veJOE generated per sec per JOE staked, in parts per 1e18
     uint256 public baseGenerationRate;
@@ -64,7 +64,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     uint256 public boostedDuration;
 
     /// @notice The upper limit of `boostedDuration`
-    uint256 public MAX_BOOSTED_DURATION;
+    uint256 public UPPER_LIMIT_BOOSTED_DURATION;
 
     mapping(address => UserInfo) public userInfos;
 
@@ -93,8 +93,8 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         uint256 _boostedDuration,
         uint256 _maxCap
     ) public initializer {
-        MAX_BOOSTED_DURATION = 365 days;
-        MAX_MAX_CAP = 100000;
+        UPPER_LIMIT_BOOSTED_DURATION = 365 days;
+        UPPER_LIMIT_MAX_CAP = 100000;
 
         require(address(_joe) != address(0), "VeJoeStaking: unexpected zero address for _joe");
         require(address(_veJoe) != address(0), "VeJoeStaking: unexpected zero address for _veJoe");
@@ -106,9 +106,12 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             _boostedThreshold != 0 && _boostedThreshold <= 100,
             "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
         );
-        require(_boostedDuration <= MAX_BOOSTED_DURATION, "VeJoeStaking: expected _boostedDuration to be <= 365 days");
         require(
-            _maxCap != 0 && _maxCap <= MAX_MAX_CAP,
+            _boostedDuration <= UPPER_LIMIT_BOOSTED_DURATION,
+            "VeJoeStaking: expected _boostedDuration to be <= 365 days"
+        );
+        require(
+            _maxCap != 0 && _maxCap <= UPPER_LIMIT_MAX_CAP,
             "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
         );
 
@@ -129,7 +132,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     function setMaxCap(uint256 _maxCap) external onlyOwner {
         require(_maxCap > maxCap, "VeJoeStaking: expected new _maxCap to be greater than existing maxCap");
         require(
-            _maxCap != 0 && _maxCap <= MAX_MAX_CAP,
+            _maxCap != 0 && _maxCap <= UPPER_LIMIT_MAX_CAP,
             "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
         );
         maxCap = _maxCap;
@@ -172,7 +175,10 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice Set boostedDuration
     /// @param _boostedDuration The new boostedDuration
     function setBoostedDuration(uint256 _boostedDuration) external onlyOwner {
-        require(_boostedDuration <= MAX_BOOSTED_DURATION, "VeJoeStaking: expected _boostedDuration to be <= 365 days");
+        require(
+            _boostedDuration <= UPPER_LIMIT_BOOSTED_DURATION,
+            "VeJoeStaking: expected _boostedDuration to be <= 365 days"
+        );
         boostedDuration = _boostedDuration;
         emit UpdateBoostedDuration(msg.sender, _boostedDuration);
     }

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -42,7 +42,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     uint256 public maxCap;
 
     /// @notice The upper limit of `maxCap`
-    uint256 public UPPER_LIMIT_MAX_CAP;
+    uint256 public upperLimitMaxCap;
 
     /// @notice Rate of veJOE generated per sec per JOE staked, in parts per 1e18
     uint256 public baseGenerationRate;
@@ -64,7 +64,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     uint256 public boostedDuration;
 
     /// @notice The upper limit of `boostedDuration`
-    uint256 public UPPER_LIMIT_BOOSTED_DURATION;
+    uint256 public upperLimitBoostedDuration;
 
     mapping(address => UserInfo) public userInfos;
 
@@ -93,9 +93,6 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         uint256 _boostedDuration,
         uint256 _maxCap
     ) public initializer {
-        UPPER_LIMIT_BOOSTED_DURATION = 365 days;
-        UPPER_LIMIT_MAX_CAP = 100000;
-
         require(address(_joe) != address(0), "VeJoeStaking: unexpected zero address for _joe");
         require(address(_veJoe) != address(0), "VeJoeStaking: unexpected zero address for _veJoe");
         require(
@@ -106,12 +103,16 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             _boostedThreshold != 0 && _boostedThreshold <= 100,
             "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
         );
+
+        upperLimitBoostedDuration = 365 days;
         require(
-            _boostedDuration <= UPPER_LIMIT_BOOSTED_DURATION,
+            _boostedDuration <= upperLimitBoostedDuration,
             "VeJoeStaking: expected _boostedDuration to be <= 365 days"
         );
+
+        upperLimitMaxCap = 100000;
         require(
-            _maxCap != 0 && _maxCap <= UPPER_LIMIT_MAX_CAP,
+            _maxCap != 0 && _maxCap <= upperLimitMaxCap,
             "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
         );
 
@@ -132,7 +133,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     function setMaxCap(uint256 _maxCap) external onlyOwner {
         require(_maxCap > maxCap, "VeJoeStaking: expected new _maxCap to be greater than existing maxCap");
         require(
-            _maxCap != 0 && _maxCap <= UPPER_LIMIT_MAX_CAP,
+            _maxCap != 0 && _maxCap <= upperLimitMaxCap,
             "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
         );
         maxCap = _maxCap;
@@ -176,7 +177,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @param _boostedDuration The new boostedDuration
     function setBoostedDuration(uint256 _boostedDuration) external onlyOwner {
         require(
-            _boostedDuration <= UPPER_LIMIT_BOOSTED_DURATION,
+            _boostedDuration <= upperLimitBoostedDuration,
             "VeJoeStaking: expected _boostedDuration to be <= 365 days"
         );
         boostedDuration = _boostedDuration;

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -107,7 +107,10 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
         );
         require(_boostedDuration <= MAX_BOOSTED_DURATION, "VeJoeStaking: expected _boostedDuration to be <= 15 days");
-        require(_maxCap > 0 && _maxCap <= MAX_MAX_CAP, "VeJoeStaking: expected new _maxCap to be > 0 and <= 100000");
+        require(
+            _maxCap != 0 && _maxCap <= MAX_MAX_CAP,
+            "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
+        );
 
         __Ownable_init();
 
@@ -125,7 +128,10 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @param _maxCap The new maxCap
     function setMaxCap(uint256 _maxCap) external onlyOwner {
         require(_maxCap > maxCap, "VeJoeStaking: expected new _maxCap to be greater than existing maxCap");
-        require(_maxCap > 0 && _maxCap <= MAX_MAX_CAP, "VeJoeStaking: expected new _maxCap to be > 0 and <= 100000");
+        require(
+            _maxCap != 0 && _maxCap <= MAX_MAX_CAP,
+            "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
+        );
         maxCap = _maxCap;
         emit UpdateMaxCap(msg.sender, _maxCap);
     }

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -73,7 +73,7 @@ describe("VeJoe Staking", function () {
       await expect(
         this.veJoeStaking.connect(this.dev).setMaxCap(100001)
       ).to.be.revertedWith(
-        "VeJoeStaking: expected new _maxCap to be greater than 0 and leq to 100000"
+        "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
       );
     });
 
@@ -169,11 +169,19 @@ describe("VeJoe Staking", function () {
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
+    it("should not allow owner to setBoostedThreshold to 0", async function () {
+      await expect(
+        this.veJoeStaking.connect(this.dev).setBoostedThreshold(0)
+      ).to.be.revertedWith(
+        "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
+      );
+    });
+
     it("should not allow owner to setBoostedThreshold greater than 100", async function () {
       await expect(
         this.veJoeStaking.connect(this.dev).setBoostedThreshold(101)
       ).to.be.revertedWith(
-        "VeJoeStaking: expected new _boostedThreshold to be less than or equal to 100"
+        "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
       );
     });
 
@@ -195,14 +203,35 @@ describe("VeJoe Staking", function () {
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
-    it("should allow owner to setBoostedThreshold", async function () {
+    it("should not allow non-owner to setBoostedDuration greater than 365 days", async function () {
+      const secondsInHour = 60 * 60;
+      const secondsInDay = secondsInHour * 24;
+      const secondsInYear = secondsInDay * 365;
+      await expect(
+        this.veJoeStaking
+          .connect(this.alice)
+          .setBoostedDuration(secondsInYear + 1)
+      ).to.be.revertedWith(
+        "VeJoeStaking: expected _boostedDuration to be <= 365 days"
+      );
+    });
+
+    it("should allow owner to setBoostedThreshold to upper limit", async function () {
+      const secondsInHour = 60 * 60;
+      const secondsInDay = secondsInHour * 24;
+      const secondsInYear = secondsInDay * 365;
+
       expect(await this.veJoeStaking.boostedDuration()).to.be.equal(
         this.boostedDuration
       );
 
-      await this.veJoeStaking.connect(this.dev).setBoostedDuration(100);
+      await this.veJoeStaking
+        .connect(this.dev)
+        .setBoostedDuration(secondsInYear);
 
-      expect(await this.veJoeStaking.boostedDuration()).to.be.equal(100);
+      expect(await this.veJoeStaking.boostedDuration()).to.be.equal(
+        secondsInYear
+      );
     });
   });
 

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -203,13 +203,13 @@ describe("VeJoe Staking", function () {
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
-    it("should not allow non-owner to setBoostedDuration greater than 365 days", async function () {
+    it("should not allow owner to setBoostedDuration greater than 365 days", async function () {
       const secondsInHour = 60 * 60;
       const secondsInDay = secondsInHour * 24;
       const secondsInYear = secondsInDay * 365;
       await expect(
         this.veJoeStaking
-          .connect(this.alice)
+          .connect(this.dev)
           .setBoostedDuration(secondsInYear + 1)
       ).to.be.revertedWith(
         "VeJoeStaking: expected _boostedDuration to be <= 365 days"


### PR DESCRIPTION
This PR adds checks to enforce:

- `boostedThreshold > 0`
- `boostedDuration <= 365 days`
- `maxCap <= 100000`

and also adds tests