### PR TITLE
Add constant speed up support to veJoeStaking

### DIFF
--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -31,7 +31,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         uint256 lastClaimTimestamp;
         uint256 speedUpEndTimestamp;
         /**
-         * @notice We do some fancy math here. Basically, any point in time, the amount of JOEs
+         * @notice We do some fancy math here. Basically, any point in time, the amount of veJOE
          * entitled to a user but is pending to be distributed is:
          *
          *   pendingReward = pendingBaseReward + pendingSpeedUpReward
@@ -109,18 +109,12 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         VeJoeToken _veJoe,
         uint256 _veJoePerSharePerSec,
         uint256 _speedUpVeJoePerSharePerSec,
-        uint256 _maxCap,
         uint256 _speedUpThreshold,
-        uint256 _speedUpDuration
+        uint256 _speedUpDuration,
+        uint256 _maxCap,
     ) public initializer {
         require(address(_joe) != address(0), "VeJoeStaking: unexpected zero address for _joe");
         require(address(_veJoe) != address(0), "VeJoeStaking: unexpected zero address for _veJoe");
-
-        upperLimitMaxCap = 100000;
-        require(
-            _maxCap != 0 && _maxCap <= upperLimitMaxCap,
-            "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
-        );
 
         require(
             _speedUpThreshold != 0 && _speedUpThreshold <= 100,
@@ -131,6 +125,12 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         require(
             _speedUpDuration <= upperLimitSpeedUpDuration,
             "VeJoeStaking: expected _speedUpDuration to be <= 365 days"
+        );
+
+        upperLimitMaxCap = 100000;
+        require(
+            _maxCap != 0 && _maxCap <= upperLimitMaxCap,
+            "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
         );
 
         __Ownable_init();

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -63,6 +63,9 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice veJOE per sec per JOE staked, scaled to `VEJOE_PER_SHARE_PER_SEC_PRECISION`
     uint256 public veJoePerSharePerSec;
 
+    /// @notice speed up veJOE per sec per JOE staked, scaled to `VEJOE_PER_SHARE_PER_SEC_PRECISION`
+    uint256 public speedUpVeJoePerSharePerSec;
+
     /// @notice Precision of `veJoePerSharePerSec`
     uint256 public VEJOE_PER_SHARE_PER_SEC_PRECISION;
 
@@ -99,6 +102,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         IERC20Upgradeable _joe,
         VeJoeToken _veJoe,
         uint256 _veJoePerSharePerSec,
+        uint256 _speedUpVeJoePerSharePerSec,
         uint256 _maxCap,
         uint256 _speedUpThreshold,
         uint256 _speedUpDuration
@@ -131,6 +135,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         joe = _joe;
         veJoe = _veJoe;
         veJoePerSharePerSec = _veJoePerSharePerSec;
+        speedUpVeJoePerSharePerSec = _speedUpVeJoePerSharePerSec;
         lastRewardTimestamp = block.timestamp;
         ACC_VEJOE_PER_SHARE_PRECISION = 1e18;
         VEJOE_PER_SHARE_PER_SEC_PRECISION = 1e18;
@@ -284,7 +289,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
                 ? user.speedUpEndTimestamp
                 : block.timestamp;
             uint256 speedUpSecondsElapsed = speedUpCeiling.sub(user.lastClaimTimestamp);
-            uint256 speedUpAccVeJoePerJoe = speedUpSecondsElapsed.mul(veJoePerSharePerSec);
+            uint256 speedUpAccVeJoePerJoe = speedUpSecondsElapsed.mul(speedUpVeJoePerSharePerSec);
             pendingSpeedUpVeJoe = speedUpAccVeJoePerJoe.mul(user.balance).div(ACC_VEJOE_PER_SHARE_PRECISION);
         }
 

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -34,10 +34,16 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
          * @notice We do some fancy math here. Basically, any point in time, the amount of JOEs
          * entitled to a user but is pending to be distributed is:
          *
-         *   pending reward = baseReward + speedUpReward
-         *   baseReward = (user.balance * accVeJoePerShare) - user.rewardDebt
-         *   speedUpReward =
+         *   pendingReward = pendingBaseReward + pendingSpeedUpReward
          *
+         *   pendingBaseReward = (user.balance * accVeJoePerShare) - user.rewardDebt
+         *
+         *   if user.speedUpEndTimestamp != 0:
+         *     speedUpCeilingTimestamp = min(block.timestamp, user.speedUpEndTimestamp)
+         *     speedUpSecondsElapsed = speedUpCeilingTimestamp - user.lastClaimTimestamp
+         *     pendingSpeedUpReward = speedUpSecondsElapsed * user.balance * speedUpVeJoePerSharePerSec
+         *   else:
+         *     pendingSpeedUpReward = 0
          */
     }
 
@@ -285,10 +291,10 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         // Calculate amount of pending speed up veJOE
         uint256 pendingSpeedUpVeJoe = 0;
         if (user.speedUpEndTimestamp != 0) {
-            uint256 speedUpCeiling = block.timestamp > user.speedUpEndTimestamp
+            uint256 speedUpCeilingTimestamp = block.timestamp > user.speedUpEndTimestamp
                 ? user.speedUpEndTimestamp
                 : block.timestamp;
-            uint256 speedUpSecondsElapsed = speedUpCeiling.sub(user.lastClaimTimestamp);
+            uint256 speedUpSecondsElapsed = speedUpCeilingTimestamp.sub(user.lastClaimTimestamp);
             uint256 speedUpAccVeJoePerJoe = speedUpSecondsElapsed.mul(speedUpVeJoePerSharePerSec);
             pendingSpeedUpVeJoe = speedUpAccVeJoePerJoe.mul(user.balance).div(ACC_VEJOE_PER_SHARE_PRECISION);
         }

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -316,7 +316,14 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
 
         userInfo.rewardDebt = accVeJoePerShare.mul(userInfo.balance).div(ACC_VEJOE_PER_SHARE_PRECISION);
 
+        // If user's speed up period has ended, reset `speedUpEndTimestamp` to 0
+        if (userInfo.speedUpEndTimestamp != 0 && block.timestamp >= userInfo.speedUpEndTimestamp) {
+            userInfo.speedUpEndTimestamp = 0;
+        }
+
         if (veJoeToClaim > 0) {
+            userInfo.lastClaimTimestamp = block.timestamp;
+
             veJoe.mint(msg.sender, veJoeToClaim);
             emit Claim(msg.sender, veJoeToClaim);
         }

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -85,16 +85,12 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice The length of time a user receives speed up benefits
     uint256 public speedUpDuration;
 
-    /// @notice The upper limit of `speedUpDuration`
-    uint256 public upperLimitSpeedUpDuration;
-
     mapping(address => UserInfo) public userInfos;
 
     event Claim(address indexed user, uint256 amount);
     event Deposit(address indexed user, uint256 amount);
     event UpdateMaxCap(address indexed user, uint256 maxCap);
     event UpdateRewardVars(uint256 lastRewardTimestamp, uint256 accVeJoePerShare);
-    event UpdateSpeedUpDuration(address indexed user, uint256 speedUpDuration);
     event UpdateSpeedUpThreshold(address indexed user, uint256 speedUpThreshold);
     event UpdateVeJoePerSharePerSec(address indexed user, uint256 veJoePerSharePerSec);
     event Withdraw(address indexed user, uint256 amount);
@@ -124,11 +120,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             "VeJoeStaking: expected _speedUpThreshold to be > 0 and <= 100"
         );
 
-        upperLimitSpeedUpDuration = 365 days;
-        require(
-            _speedUpDuration <= upperLimitSpeedUpDuration,
-            "VeJoeStaking: expected _speedUpDuration to be <= 365 days"
-        );
+        require(_speedUpDuration <= 365 days, "VeJoeStaking: expected _speedUpDuration to be <= 365 days");
 
         upperLimitMaxCap = 100000;
         require(
@@ -179,17 +171,6 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         );
         speedUpThreshold = _speedUpThreshold;
         emit UpdateSpeedUpThreshold(msg.sender, _speedUpThreshold);
-    }
-
-    /// @notice Set speedUpDuration
-    /// @param _speedUpDuration The new speedUpDurationn
-    function setSpeedUpDuration(uint256 _speedUpDuration) external onlyOwner {
-        require(
-            _speedUpDuration <= upperLimitSpeedUpDuration,
-            "VeJoeStaking: expected _speedUpDuration to be <= 365 days"
-        );
-        speedUpDuration = _speedUpDuration;
-        emit UpdateSpeedUpDuration(msg.sender, _speedUpDuration);
     }
 
     /// @notice Deposits JOE to start staking for veJOE. Note that any pending veJOE

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -28,10 +28,10 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     ///     4. Unstaked JOE
     /// `boostEndTimestamp`: Timestamp of when user stops receiving boost benefits. Note that
     /// this will be reset to 0 after the end of a boost
+    /// `rewardDebt` is the reward debt of the user. Doesn't take into account the boosted generation.
     struct UserInfo {
         uint256 balance;
-        uint256 lastRewardTimestamp;
-        uint256 boostEndTimestamp;
+        uint256 rewardDebt;
     }
 
     IERC20Upgradeable public joe;
@@ -44,70 +44,46 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice The upper limit of `maxCap`
     uint256 public upperLimitMaxCap;
 
+    /// @notice The accrued veJoe per share
+    uint256 public accVeJoePerShare;
+    uint256 public lastRewardTimestamp;
+
     /// @notice Rate of veJOE generated per sec per JOE staked, in parts per 1e18
     uint256 public baseGenerationRate;
-
-    /// @notice Boosted rate of veJOE generated per sec per JOE staked, in parts per 1e18
-    uint256 public boostedGenerationRate;
 
     /// @notice Precision of `baseGenerationRate` and `boostedGenerationRate`
     uint256 public PRECISION;
 
-    /// @notice Percentage of user's current staked JOE user has to deposit in order to start
-    /// receiving boosted benefits, in parts per 100.
-    /// @dev Specifically, user has to deposit at least `boostedThreshold/100 * userStakedJoe` JOE.
-    /// The only exception is the user will also receive boosted benefits if it's their first
-    /// time staking.
-    uint256 public boostedThreshold;
-
-    /// @notice The length of time a user receives boosted benefits
-    uint256 public boostedDuration;
-
-    /// @notice The upper limit of `boostedDuration`
-    uint256 public upperLimitBoostedDuration;
-
     mapping(address => UserInfo) public userInfos;
 
     event Claim(address indexed user, uint256 amount);
-    event Deposit(address indexed user, uint256 amount);
-    event UpdateBaseGenerationRate(address indexed user, uint256 baseGenerationRate);
-    event UpdateBoostedDuration(address indexed user, uint256 boostedDuration);
-    event UpdateBoostedGenerationRate(address indexed user, uint256 boostedGenerationRate);
-    event UpdateBoostedThreshold(address indexed user, uint256 boostedThreshold);
+    event UpdateBaseGenerationRate(
+        address indexed user,
+        uint256 baseGenerationRate
+    );
     event UpdateMaxCap(address indexed user, uint256 maxCap);
+    event Deposit(address indexed user, uint256 amount);
     event Withdraw(address indexed user, uint256 amount);
+    event Update(uint256 lastRewardTimestamp, uint256 accVeJoePerShare);
 
     /// @notice Initialize with needed parameters
     /// @param _joe Address of the JOE token contract
     /// @param _veJoe Address of the veJOE token contract
     /// @param _baseGenerationRate Rate of veJOE generated per sec per JOE staked
-    /// @param _boostedGenerationRate Boosted rate of veJOE generated per sec per JOE staked
-    /// @param _boostedThreshold Percentage of total staked JOE user has to deposit to be boosted
-    /// @param _boostedDuration Length of time a user receives boosted benefits
+    /// @param _maxCap the maximum amount of veJOE received per JOE staked
     function initialize(
         IERC20Upgradeable _joe,
         VeJoeToken _veJoe,
         uint256 _baseGenerationRate,
-        uint256 _boostedGenerationRate,
-        uint256 _boostedThreshold,
-        uint256 _boostedDuration,
         uint256 _maxCap
     ) public initializer {
-        require(address(_joe) != address(0), "VeJoeStaking: unexpected zero address for _joe");
-        require(address(_veJoe) != address(0), "VeJoeStaking: unexpected zero address for _veJoe");
         require(
-            _boostedGenerationRate > _baseGenerationRate,
-            "VeJoeStaking: expected _boostedGenerationRate to be greater than _baseGenerationRate"
+            address(_joe) != address(0),
+            "VeJoeStaking: unexpected zero address for _joe"
         );
         require(
-            _boostedThreshold != 0 && _boostedThreshold <= 100,
-            "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
-        );
-
-        upperLimitBoostedDuration = 365 days;
-        require(
-            _boostedDuration <= upperLimitBoostedDuration,
-            "VeJoeStaking: expected _boostedDuration to be <= 365 days"
+            address(_veJoe) != address(0),
+            "VeJoeStaking: unexpected zero address for _veJoe"
         );
 
         upperLimitMaxCap = 100000;
@@ -122,16 +98,17 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         joe = _joe;
         veJoe = _veJoe;
         baseGenerationRate = _baseGenerationRate;
-        boostedGenerationRate = _boostedGenerationRate;
-        boostedThreshold = _boostedThreshold;
-        boostedDuration = _boostedDuration;
+        lastRewardTimestamp = block.timestamp;
         PRECISION = 1e18;
     }
 
     /// @notice Set maxCap
     /// @param _maxCap The new maxCap
     function setMaxCap(uint256 _maxCap) external onlyOwner {
-        require(_maxCap > maxCap, "VeJoeStaking: expected new _maxCap to be greater than existing maxCap");
+        require(
+            _maxCap > maxCap,
+            "VeJoeStaking: expected new _maxCap to be greater than existing maxCap"
+        );
         require(
             _maxCap != 0 && _maxCap <= upperLimitMaxCap,
             "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
@@ -142,90 +119,34 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
 
     /// @notice Set baseGenerationRate
     /// @param _baseGenerationRate The new baseGenerationRate
-    function setBaseGenerationRate(uint256 _baseGenerationRate) external onlyOwner {
-        require(
-            _baseGenerationRate < boostedGenerationRate,
-            "VeJoeStaking: expected new _baseGenerationRate to be less than boostedGenerationRate"
-        );
+    function setBaseGenerationRate(uint256 _baseGenerationRate)
+        external
+        onlyOwner
+    {
+        update();
         baseGenerationRate = _baseGenerationRate;
         emit UpdateBaseGenerationRate(msg.sender, _baseGenerationRate);
-    }
-
-    /// @notice Set boostedGenerationRate
-    /// @param _boostedGenerationRate The new boostedGenerationRate
-    function setBoostedGenerationRate(uint256 _boostedGenerationRate) external onlyOwner {
-        require(
-            _boostedGenerationRate > baseGenerationRate,
-            "VeJoeStaking: expected new _boostedGenerationRate to be greater than baseGenerationRate"
-        );
-        boostedGenerationRate = _boostedGenerationRate;
-        emit UpdateBoostedGenerationRate(msg.sender, _boostedGenerationRate);
-    }
-
-    /// @notice Set boostedThreshold
-    /// @param _boostedThreshold The new boostedThreshold
-    function setBoostedThreshold(uint256 _boostedThreshold) external onlyOwner {
-        require(
-            _boostedThreshold != 0 && _boostedThreshold <= 100,
-            "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
-        );
-        boostedThreshold = _boostedThreshold;
-        emit UpdateBoostedThreshold(msg.sender, _boostedThreshold);
-    }
-
-    /// @notice Set boostedDuration
-    /// @param _boostedDuration The new boostedDuration
-    function setBoostedDuration(uint256 _boostedDuration) external onlyOwner {
-        require(
-            _boostedDuration <= upperLimitBoostedDuration,
-            "VeJoeStaking: expected _boostedDuration to be <= 365 days"
-        );
-        boostedDuration = _boostedDuration;
-        emit UpdateBoostedDuration(msg.sender, _boostedDuration);
     }
 
     /// @notice Deposits JOE to start staking for veJOE. Note that any pending veJOE
     /// will also be claimed in the process.
     /// @param _amount The amount of JOE to deposit
     function deposit(uint256 _amount) external {
-        require(_amount > 0, "VeJoeStaking: expected deposit amount to be greater than zero");
+        require(
+            _amount > 0,
+            "VeJoeStaking: expected deposit amount to be greater than zero"
+        );
+        update();
+        if (_getUserHasNonZeroBalance(msg.sender)){
+            _claim();
+        }
 
         UserInfo storage userInfo = userInfos[msg.sender];
 
-        if (_getUserHasNonZeroBalance(msg.sender)) {
-            // If user already has staked JOE, we first send them any pending veJOE
-            _claim();
-
-            uint256 userStakedJoe = userInfo.balance;
-
-            uint256 userVeJoeBalance = veJoe.balanceOf(msg.sender);
-            uint256 userMaxVeJoeCap = userStakedJoe.mul(maxCap);
-
-            // If the user is currently at their max veJOE cap, we need to update
-            // their `lastRewardTimestamp` to now to prevent passive veJOE accrual
-            // after user hit their max cap.
-            if (userVeJoeBalance == userMaxVeJoeCap) {
-                userInfo.lastRewardTimestamp = block.timestamp;
-            }
-
-            userInfo.balance = userStakedJoe.add(_amount);
-
-            // User is eligible for boosted benefits if `_amount` is at least
-            // `boostedThreshold / 100 * userStakedJoe`
-            if (_amount.mul(100) >= boostedThreshold.mul(userStakedJoe)) {
-                userInfo.boostEndTimestamp = block.timestamp.add(boostedDuration);
-            }
-        } else {
-            // If the user's `lastRewardTimestamp` is 0, i.e. if this is the user's first time staking,
-            // then they will receive boosted benefits.
-            // Note that it is important we perform this check **before** we update the user's `lastRewardTimestamp`
-            // down below.
-            if (userInfo.lastRewardTimestamp == 0) {
-                userInfo.boostEndTimestamp = block.timestamp.add(boostedDuration);
-            }
-            userInfo.balance = _amount;
-            userInfo.lastRewardTimestamp = block.timestamp;
-        }
+        userInfo.balance = userInfo.balance.add(_amount);
+        userInfo.rewardDebt = accVeJoePerShare.mul(userInfo.balance).div(
+            PRECISION
+        );
 
         joe.safeTransferFrom(msg.sender, address(this), _amount);
 
@@ -236,7 +157,10 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// lose all of your current veJOE.
     /// @param _amount The amount of JOE to unstake
     function withdraw(uint256 _amount) external {
-        require(_amount > 0, "VeJoeStaking: expected withdraw amount to be greater than zero");
+        require(
+            _amount > 0,
+            "VeJoeStaking: expected withdraw amount to be greater than zero"
+        );
 
         UserInfo storage userInfo = userInfos[msg.sender];
 
@@ -244,14 +168,16 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             userInfo.balance >= _amount,
             "VeJoeStaking: cannot withdraw greater amount of JOE than currently staked"
         );
+        update();
+        //We don't need to claim as veJOE balance will be reseted to 0
 
         userInfo.balance = userInfo.balance.sub(_amount);
-        userInfo.lastRewardTimestamp = block.timestamp;
-        userInfo.boostEndTimestamp = 0;
+        userInfo.rewardDebt = accVeJoePerShare.mul(userInfo.balance).div(
+            PRECISION
+        );
 
         // Burn the user's current veJOE balance
-        uint256 userVeJoeBalance = veJoe.balanceOf(msg.sender);
-        veJoe.burnFrom(msg.sender, userVeJoeBalance);
+        veJoe.burnFrom(msg.sender, veJoe.balanceOf(msg.sender));
 
         // Send user their requested amount of staked JOE
         joe.safeTransfer(msg.sender, _amount);
@@ -261,105 +187,79 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
 
     /// @notice Claim any pending veJOE
     function claim() external {
-        require(_getUserHasNonZeroBalance(msg.sender), "VeJoeStaking: cannot claim veJOE when no JOE is staked");
+        require(
+            _getUserHasNonZeroBalance(msg.sender),
+            "VeJoeStaking: cannot claim veJOE when no JOE is staked"
+        );
+        update();
         _claim();
     }
 
     /// @notice Get the pending amount of veJOE for a given user
     /// @param _user The user to lookup
-    /// @return The number of pending veJOE tokens for `_user`
-    function getPendingVeJoe(address _user) public view returns (uint256) {
+    /// @return pendingVeJoe The number of pending veJOE tokens for `_user`
+    function getPendingVeJoe(address _user)
+        public
+        view
+        returns (uint256 pendingVeJoe)
+    {
         if (!_getUserHasNonZeroBalance(_user)) {
             return 0;
         }
 
         UserInfo memory user = userInfos[_user];
 
-        uint256 secondsElapsed = block.timestamp.sub(user.lastRewardTimestamp);
-        if (secondsElapsed == 0) {
-            return 0;
+        // Calculate amount of pending veJOE
+        uint256 _accVeJoePerShare = accVeJoePerShare;
+        uint256 secondsElapsed = block.timestamp.sub(lastRewardTimestamp);
+        if (secondsElapsed > 0) {
+            _accVeJoePerShare.add(secondsElapsed.mul(baseGenerationRate));
         }
 
-        // Calculate amount of pending veJOE based on:
-        // 1. Seconds elapsed since last reward timestamp
-        // 2. Generation rate that the user is receiving
-        // 3. Current amount of user's staked JOE
-        uint256 pendingVeJoe;
-
-        if (block.timestamp <= user.boostEndTimestamp) {
-            // If the current timestamp is less than or equal to the user's `boostEndTimestamp`,
-            // that means the user is currently receiving boosted benefits so they should receive
-            // `boostedGenerationRate`.
-            uint256 accVeJoePerJoe = secondsElapsed.mul(boostedGenerationRate);
-            pendingVeJoe = accVeJoePerJoe.mul(user.balance).div(PRECISION);
-        } else {
-            if (user.boostEndTimestamp != 0) {
-                // If `user.boostEndTimestamp != 0` then, we know for certain that
-                // `user.boostEndTimestamp >= user.lastRewardTimestamp`.
-                // Proof by contradiction:
-                // 1. Assume that `user.boostEndTimestamp != 0` and
-                //    `user.boostEndTimestamp < user.lastRewardTimestamp`.
-                // 2. There are 4 cases when a user's `lastRewardTimestamp` is updated:
-                //    a. User claimed pending veJOE: We know that anytime a user claims some veJOE,
-                //       if the current timestamp is greater than or equal to `user.boostEndTimestamp`,
-                //       we will update `user.boostEndTimestamp` to be `0` (see `_claim` method). This
-                //       means that `user.boostEndTimestamp` should be `0` but that contradicts our
-                //       assumption that `user.boostEndTimestamp != 0`.
-                //    b. User staked JOE with zero balance: If a user is staking JOE with zero balance, it
-                //       either means 1) this is their first time staking or 2) their last action was performing
-                //       unstaking JOE.
-                //       For first time stakers, we set `user.lastRewardTimestamp` to `block.timestamp`
-                //       and `user.boostEndTimestamp` to `block.timestamp + boostedDuration`. This contradicts
-                //       our assumption that `user.boostEndTimestamp < user.lastRewardTimestamp`.
-                //       If the user's previous action was withdraw, that means that their `user.boostEndTimestamp`
-                //       was reset to `0`. This contradicts our assumption that `user.boostEndTimestamp != 0`.
-                //    c. User staked JOE with non-zero balance and is at their max veJOE cap after claim: Anytime
-                //       we perform a claim, if `user.boostEndTimestamp` is leq than the current timestamp, we
-                //       reset it to `0`. This contradicts our assumption that `user.boostEndTimestamp != 0`.
-                //    d. User unstaked JOE: Whenever a user unstakes JOE, we reset `user.boostEndTimestamp`
-                //       to be 0. This contradicts our assumption that `user.boostEndTimestamp != 0`.
-                // QED.
-
-                // Now we know that `0 < user.lastRewardTimestamp <= user.boostEndTimestamp < block.timestamp`.
-                // In this case, we need to properly provide them the boosted generation rate for
-                // those `boostEndTimestamp - lastRewardTimestamp` seconds.
-                uint256 boostedTimeElapsed = user.boostEndTimestamp.sub(user.lastRewardTimestamp);
-                uint256 boostedAccVeJoePerJoe = boostedTimeElapsed.mul(boostedGenerationRate);
-                uint256 boostedPendingVeJoe = boostedAccVeJoePerJoe.mul(user.balance);
-
-                uint256 baseTimeElapsed = block.timestamp.sub(user.boostEndTimestamp);
-                uint256 baseAccVeJoePerVeJoe = baseTimeElapsed.mul(baseGenerationRate);
-                uint256 basePendingVeJoe = baseAccVeJoePerVeJoe.mul(user.balance);
-
-                pendingVeJoe = boostedPendingVeJoe.add(basePendingVeJoe).div(PRECISION);
-            } else {
-                // In this case, the user is simply generating veJOE at `baseGenerationRate` for
-                // the duration of `secondsElapsed`.
-                uint256 accVeJoePerJoe = secondsElapsed.mul(baseGenerationRate);
-                pendingVeJoe = accVeJoePerJoe.mul(user.balance).div(PRECISION);
-            }
-        }
+        pendingVeJoe = _accVeJoePerShare.mul(user.balance).div(PRECISION).sub(
+            user.rewardDebt
+        );
 
         // Get the user's current veJOE balance and maximum veJOE they can hold
         uint256 userVeJoeBalance = veJoe.balanceOf(_user);
         uint256 userMaxVeJoeCap = user.balance.mul(maxCap);
 
-        if (userVeJoeBalance < userMaxVeJoeCap) {
-            if (userVeJoeBalance.add(pendingVeJoe) > userMaxVeJoeCap) {
-                return userMaxVeJoeCap.sub(userVeJoeBalance);
-            } else {
-                return pendingVeJoe;
-            }
-        } else {
+        if (userVeJoeBalance >= userMaxVeJoeCap) {
             // User already holds maximum amount of veJOE so there is no pending veJOE
             return 0;
         }
+
+        if (userVeJoeBalance.add(pendingVeJoe) > userMaxVeJoeCap) {
+            return userMaxVeJoeCap.sub(userVeJoeBalance);
+        } else {
+            return pendingVeJoe;
+        }
+    }
+
+    // Update reward variables of the given pool to be up-to-date.
+    function update() public {
+        if (block.timestamp <= lastRewardTimestamp) {
+            return;
+        }
+        if (joe.balanceOf(address(this)) == 0) {
+            lastRewardTimestamp = block.timestamp;
+            return;
+        }
+        uint256 timeElapsed = block.timestamp.sub(lastRewardTimestamp);
+        uint256 veJoeReward = timeElapsed.mul(baseGenerationRate);
+        accVeJoePerShare = accVeJoePerShare.add(veJoeReward);
+        lastRewardTimestamp = block.timestamp;
+        emit Update(lastRewardTimestamp, accVeJoePerShare);
     }
 
     /// @notice Checks to see if a given user currently has staked JOE
     /// @param _user The user address to check
     /// @return Whether `_user` currently has staked JOE
-    function _getUserHasNonZeroBalance(address _user) private view returns (bool) {
+    function _getUserHasNonZeroBalance(address _user)
+        private
+        view
+        returns (bool)
+    {
         return userInfos[_user].balance > 0;
     }
 
@@ -369,15 +269,11 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
 
         UserInfo storage userInfo = userInfos[msg.sender];
 
-        // If user's boost period has ended, reset `boostEndTimestamp` to 0
-        if (userInfo.boostEndTimestamp != 0 && block.timestamp >= userInfo.boostEndTimestamp) {
-            userInfo.boostEndTimestamp = 0;
-        }
+        userInfo.rewardDebt = accVeJoePerShare.mul(userInfo.balance).div(
+            PRECISION
+        );
 
         if (veJoeToClaim > 0) {
-            // Update user's last reward timestamp
-            userInfo.lastRewardTimestamp = block.timestamp;
-
             veJoe.mint(msg.sender, veJoeToClaim);
             emit Claim(msg.sender, veJoeToClaim);
         }

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -185,7 +185,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             _speedUpDuration <= upperLimitSpeedUpDuration,
             "VeJoeStaking: expected _speedUpDuration to be <= 365 days"
         );
-        speedUpDuration = speedUpDuration;
+        speedUpDuration = _speedUpDuration;
         emit UpdateSpeedUpDuration(msg.sender, _speedUpDuration);
     }
 

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -218,11 +218,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
                 userInfo.speedUpEndTimestamp = block.timestamp.add(speedUpDuration);
             }
         } else {
-            // If the user's `lastClaimTimestamp` is 0, i.e. if this is the user's first time staking,
-            // then they will receive speed up benefits.
-            if (userInfo.lastClaimTimestamp == 0) {
-                userInfo.speedUpEndTimestamp = block.timestamp.add(speedUpDuration);
-            }
+            userInfo.speedUpEndTimestamp = block.timestamp.add(speedUpDuration);
             userInfo.lastClaimTimestamp = block.timestamp;
         }
 

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -57,11 +57,11 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     mapping(address => UserInfo) public userInfos;
 
     event Claim(address indexed user, uint256 amount);
+    event Deposit(address indexed user, uint256 amount);
+    event Update(uint256 lastRewardTimestamp, uint256 accVeJoePerShare);
     event UpdateBaseGenerationRate(address indexed user, uint256 baseGenerationRate);
     event UpdateMaxCap(address indexed user, uint256 maxCap);
-    event Deposit(address indexed user, uint256 amount);
     event Withdraw(address indexed user, uint256 amount);
-    event Update(uint256 lastRewardTimestamp, uint256 accVeJoePerShare);
 
     /// @notice Initialize with needed parameters
     /// @param _joe Address of the JOE token contract
@@ -202,7 +202,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         }
     }
 
-    // Update reward variables of the given pool to be up-to-date.
+    // Update reward variables of veJOE.
     function update() public {
         if (block.timestamp <= lastRewardTimestamp) {
             return;

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -208,6 +208,16 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         if (_getUserHasNonZeroBalance(msg.sender)) {
             uint256 userStakedJoe = userInfo.balance;
 
+            uint256 userVeJoeBalance = veJoe.balanceOf(msg.sender);
+            uint256 userMaxVeJoeCap = userStakedJoe.mul(maxCap);
+
+            // If the user is currently at their max veJOE cap, we need to update
+            // their `lastClaimTimestamp` to now to prevent passive veJOE accrual
+            // after user hit their max cap.
+            if (userVeJoeBalance == userMaxVeJoeCap) {
+                userInfo.lastClaimTimestamp = block.timestamp;
+            }
+
             // User is eligible for speed up benefits if `_amount` is at least
             // `speedUpThreshold / 100 * userStakedJoe`
             if (_amount.mul(100) >= speedUpThreshold.mul(userStakedJoe)) {

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -111,7 +111,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         uint256 _speedUpVeJoePerSharePerSec,
         uint256 _speedUpThreshold,
         uint256 _speedUpDuration,
-        uint256 _maxCap,
+        uint256 _maxCap
     ) public initializer {
         require(address(_joe) != address(0), "VeJoeStaking: unexpected zero address for _joe");
         require(address(_veJoe) != address(0), "VeJoeStaking: unexpected zero address for _veJoe");
@@ -215,7 +215,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             // If the user's `lastClaimTimestamp` is 0, i.e. if this is the user's first time staking,
             // then they will receive speed up benefits.
             if (userInfo.lastClaimTimestamp == 0) {
-                userInfo.speedUpEndTimestamp = block.timestamp.add(boostedDuration);
+                userInfo.speedUpEndTimestamp = block.timestamp.add(speedUpDuration);
             }
         }
 

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -180,6 +180,22 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
 
         UserInfo storage userInfo = userInfos[msg.sender];
 
+        if (_getUserHasNonZeroBalance(msg.sender)) {
+            uint256 userStakedJoe = userInfo.balance;
+
+            // User is eligible for speed up benefits if `_amount` is at least
+            // `speedUpThreshold / 100 * userStakedJoe`
+            if (_amount.mul(100) >= speedUpThreshold.mul(userStakedJoe)) {
+                userInfo.speedUpEndTimestamp = block.timestamp.add(speedUpDuration);
+            }
+        } else {
+            // If the user's `lastClaimTimestamp` is 0, i.e. if this is the user's first time staking,
+            // then they will receive speed up benefits.
+            if (userInfo.lastClaimTimestamp == 0) {
+                userInfo.speedUpEndTimestamp = block.timestamp.add(boostedDuration);
+            }
+        }
+
         userInfo.balance = userInfo.balance.add(_amount);
         userInfo.rewardDebt = accVeJoePerShare.mul(userInfo.balance).div(ACC_VEJOE_PER_SHARE_PRECISION);
 

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -69,7 +69,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice veJOE per sec per JOE staked, scaled to `VEJOE_PER_SHARE_PER_SEC_PRECISION`
     uint256 public veJoePerSharePerSec;
 
-    /// @notice speed up veJOE per sec per JOE staked, scaled to `VEJOE_PER_SHARE_PER_SEC_PRECISION`
+    /// @notice Speed up veJOE per sec per JOE staked, scaled to `VEJOE_PER_SHARE_PER_SEC_PRECISION`
     uint256 public speedUpVeJoePerSharePerSec;
 
     /// @notice Precision of `veJoePerSharePerSec`
@@ -206,17 +206,11 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             // Transfer to the user their pending veJOE before updating their UserInfo
             _claim();
 
+            // We need to update user's `lastClaimTimestamp` to now to prevent
+            // passive veJOE accrual if user hit their max cap.
+            userInfo.lastClaimTimestamp = block.timestamp;
+
             uint256 userStakedJoe = userInfo.balance;
-
-            uint256 userVeJoeBalance = veJoe.balanceOf(msg.sender);
-            uint256 userMaxVeJoeCap = userStakedJoe.mul(maxCap);
-
-            // If the user is currently at their max veJOE cap, we need to update
-            // their `lastClaimTimestamp` to now to prevent passive veJOE accrual
-            // after user hit their max cap.
-            if (userVeJoeBalance == userMaxVeJoeCap) {
-                userInfo.lastClaimTimestamp = block.timestamp;
-            }
 
             // User is eligible for speed up benefits if `_amount` is at least
             // `speedUpThreshold / 100 * userStakedJoe`
@@ -301,7 +295,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         );
 
         // Calculate amount of pending speed up veJOE
-        uint256 pendingSpeedUpVeJoe = 0;
+        uint256 pendingSpeedUpVeJoe;
         if (user.speedUpEndTimestamp != 0) {
             uint256 speedUpCeilingTimestamp = block.timestamp > user.speedUpEndTimestamp
                 ? user.speedUpEndTimestamp

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -81,8 +81,8 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice Percentage of user's current staked JOE user has to deposit in order to start
     /// receiving speed up benefits, in parts per 100.
     /// @dev Specifically, user has to deposit at least `speedUpThreshold/100 * userStakedJoe` JOE.
-    /// The only exception is the user will also receive speed up benefits if it's their first
-    /// time staking.
+    /// The only exception is the user will also receive speed up benefits if they are depositing
+    /// with zero balance
     uint256 public speedUpThreshold;
 
     /// @notice The length of time a user receives speed up benefits
@@ -216,6 +216,8 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
                 userInfo.speedUpEndTimestamp = block.timestamp.add(speedUpDuration);
             }
         } else {
+            // If user is depositing with zero balance, they will automatically
+            // receive speed up benefits
             userInfo.speedUpEndTimestamp = block.timestamp.add(speedUpDuration);
             userInfo.lastClaimTimestamp = block.timestamp;
         }

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -221,6 +221,8 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         // Note that we don't need to claim as the user's veJOE balance will be reset to 0
         userInfo.balance = userInfo.balance.sub(_amount);
         userInfo.rewardDebt = accVeJoePerShare.mul(userInfo.balance).div(ACC_VEJOE_PER_SHARE_PRECISION);
+        userInfo.lastClaimTimestamp = block.timestamp;
+        userInfo.speedUpEndTimestamp = 0;
 
         // Burn the user's current veJOE balance
         veJoe.burnFrom(msg.sender, veJoe.balanceOf(msg.sender));

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -9,6 +9,8 @@ import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
 
+import "hardhat/console.sol";
+
 import "./VeJoeToken.sol";
 
 /// @title Vote Escrow Joe Staking
@@ -217,6 +219,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             if (userInfo.lastClaimTimestamp == 0) {
                 userInfo.speedUpEndTimestamp = block.timestamp.add(speedUpDuration);
             }
+            userInfo.lastClaimTimestamp = block.timestamp;
         }
 
         userInfo.balance = userInfo.balance.add(_amount);
@@ -283,7 +286,6 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
                 )
             );
         }
-
         uint256 pendingBaseVeJoe = _accVeJoePerShare.mul(user.balance).div(ACC_VEJOE_PER_SHARE_PRECISION).sub(
             user.rewardDebt
         );
@@ -299,7 +301,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
             pendingSpeedUpVeJoe = speedUpAccVeJoePerJoe.mul(user.balance).div(ACC_VEJOE_PER_SHARE_PRECISION);
         }
 
-        uint256 pendingVeJoe = pendingBaseVeJoe + pendingSpeedUpVeJoe;
+        uint256 pendingVeJoe = pendingBaseVeJoe.add(pendingSpeedUpVeJoe);
 
         // Get the user's current veJOE balance and maximum veJOE they can hold
         uint256 userVeJoeBalance = veJoe.balanceOf(_user);

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -69,11 +69,11 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice veJOE per sec per JOE staked, scaled to `VEJOE_PER_SHARE_PER_SEC_PRECISION`
     uint256 public veJoePerSharePerSec;
 
-    /// @notice The upper limit of `veJoePerSharePerSec`
-    uint256 public upperLimitVeJoePerSharePerSec;
-
     /// @notice Speed up veJOE per sec per JOE staked, scaled to `VEJOE_PER_SHARE_PER_SEC_PRECISION`
     uint256 public speedUpVeJoePerSharePerSec;
+
+    /// @notice The upper limit of `veJoePerSharePerSec` and `speedUpVeJoePerSharePerSec`
+    uint256 public upperLimitVeJoePerSharePerSec;
 
     /// @notice Precision of `veJoePerSharePerSec`
     uint256 public VEJOE_PER_SHARE_PER_SEC_PRECISION;

--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -69,6 +69,9 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice veJOE per sec per JOE staked, scaled to `VEJOE_PER_SHARE_PER_SEC_PRECISION`
     uint256 public veJoePerSharePerSec;
 
+    /// @notice The upper limit of `veJoePerSharePerSec`
+    uint256 public upperLimitVeJoePerSharePerSec;
+
     /// @notice Speed up veJOE per sec per JOE staked, scaled to `VEJOE_PER_SHARE_PER_SEC_PRECISION`
     uint256 public speedUpVeJoePerSharePerSec;
 
@@ -115,6 +118,16 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         require(address(_joe) != address(0), "VeJoeStaking: unexpected zero address for _joe");
         require(address(_veJoe) != address(0), "VeJoeStaking: unexpected zero address for _veJoe");
 
+        upperLimitVeJoePerSharePerSec = 1e36;
+        require(
+            _veJoePerSharePerSec <= upperLimitVeJoePerSharePerSec,
+            "VeJoeStaking: expected _veJoePerSharePerSec to be <= 1e36"
+        );
+        require(
+            _speedUpVeJoePerSharePerSec <= upperLimitVeJoePerSharePerSec,
+            "VeJoeStaking: expected _speedUpVeJoePerSharePerSec to be <= 1e36"
+        );
+
         require(
             _speedUpThreshold != 0 && _speedUpThreshold <= 100,
             "VeJoeStaking: expected _speedUpThreshold to be > 0 and <= 100"
@@ -125,7 +138,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
         upperLimitMaxCap = 100000;
         require(
             _maxCap != 0 && _maxCap <= upperLimitMaxCap,
-            "VeJoeStaking: expected new _maxCap to be non-zero and <= 100000"
+            "VeJoeStaking: expected _maxCap to be non-zero and <= 100000"
         );
 
         __Ownable_init();
@@ -157,6 +170,10 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
     /// @notice Set veJoePerSharePerSec
     /// @param _veJoePerSharePerSec The new veJoePerSharePerSec
     function setVeJoePerSharePerSec(uint256 _veJoePerSharePerSec) external onlyOwner {
+        require(
+            _veJoePerSharePerSec <= upperLimitVeJoePerSharePerSec,
+            "VeJoeStaking: expected _veJoePerSharePerSec to be <= 1e36"
+        );
         updateRewardVars();
         veJoePerSharePerSec = _veJoePerSharePerSec;
         emit UpdateVeJoePerSharePerSec(msg.sender, _veJoePerSharePerSec);

--- a/test/BoostedMasterChef.test.ts
+++ b/test/BoostedMasterChef.test.ts
@@ -2,7 +2,7 @@ import { ethers, network, upgrades } from "hardhat"
 import { expect } from "chai"
 import { ADDRESS_ZERO, advanceBlock, advanceBlockTo, latest, duration, increase } from "./utilities"
 
-describe.only("BoostedMasterChefJoe", function () {
+describe("BoostedMasterChefJoe", function () {
   before(async function () {
     this.signers = await ethers.getSigners()
     this.alice = this.signers[0]

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -3,7 +3,7 @@ const { ethers, network, upgrades } = require("hardhat");
 const { expect } = require("chai");
 const { describe } = require("mocha");
 
-describe("VeJoe Staking", function () {
+describe.only("VeJoe Staking", function () {
   before(async function () {
     this.VeJoeStakingCF = await ethers.getContractFactory("VeJoeStaking");
     this.VeJoeTokenCF = await ethers.getContractFactory("VeJoeToken");
@@ -319,6 +319,34 @@ describe("VeJoe Staking", function () {
       );
       // speedUpTimestamp
       expect(afterAliceUserInfo[3]).to.be.equal(0);
+    });
+
+    it("should receive speed up benefits after deposit with zero balance", async function () {
+      await this.veJoeStaking
+        .connect(this.alice)
+        .deposit(ethers.utils.parseEther("100"));
+
+      await increase(100);
+
+      await this.veJoeStaking
+        .connect(this.alice)
+        .withdraw(ethers.utils.parseEther("100"));
+
+      await increase(100);
+
+      await this.veJoeStaking
+        .connect(this.alice)
+        .deposit(ethers.utils.parseEther("1"));
+
+      const secondDepositBlock = await ethers.provider.getBlock();
+
+      const secondDepositAliceUserInfo = await this.veJoeStaking.userInfos(
+        this.alice.address
+      );
+      // speedUpEndTimestamp
+      expect(secondDepositAliceUserInfo[3]).to.be.equal(
+        secondDepositBlock.timestamp + this.speedUpDuration
+      );
     });
 
     it("should have speed up period extended after depositing speedUpThreshold and currently receiving speed up benefits", async function () {

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -393,8 +393,11 @@ describe.only("VeJoe Staking", function () {
       await this.veJoeStaking.connect(this.alice).claim();
 
       // Check veJoe balance after claim
+      // Should be sum of:
+      // baseVeJoe = 100 * 50 = 5000
+      // speedUpVeJoe = 100 * 50 = 5000
       expect(await this.veJoe.balanceOf(this.alice.address)).to.be.equal(
-        ethers.utils.parseEther("5000")
+        ethers.utils.parseEther("10000")
       );
     });
 
@@ -423,12 +426,13 @@ describe.only("VeJoe Staking", function () {
       await this.veJoeStaking.connect(this.alice).claim();
 
       // Check veJoe balance after claim
-      // Expected to have been generating at a rate of 1 for the first 10 seconds,
-      // a rate of 2 for the next 10 seconds, and a rate of 1.5 for the last 10
-      // seconds, i.e.:
-      // 100 * 10 * 1 + 100 * 10 * 2 + 100 * 10 * 1.5 = 4500
+      // For baseVeJoe, we're expected to have been generating at a rate of 1 for
+      // the first 10 seconds, a rate of 2 for the next 10 seconds, and a rate of
+      // 1.5 for the last 10 seconds, i.e.:
+      // baseVeJoe = 100 * 10 * 1 + 100 * 10 * 2 + 100 * 10 * 1.5 = 4500
+      // speedUpVeJoe = 100 * 30 = 3000
       expect(await this.veJoe.balanceOf(this.alice.address)).to.be.equal(
-        ethers.utils.parseEther("4500")
+        ethers.utils.parseEther("7500")
       );
     });
   });

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -3,7 +3,7 @@ const { ethers, network, upgrades } = require("hardhat");
 const { expect } = require("chai");
 const { describe } = require("mocha");
 
-describe("VeJoe Staking", function () {
+describe.only("VeJoe Staking", function () {
   before(async function () {
     this.VeJoeStakingCF = await ethers.getContractFactory("VeJoeStaking");
     this.VeJoeTokenCF = await ethers.getContractFactory("VeJoeToken");
@@ -34,9 +34,6 @@ describe("VeJoe Staking", function () {
       this.joe.address, // _joe
       this.veJoe.address, // _veJoe
       this.baseGenerationRate, // _baseGenerationRate
-      this.boostedGenerationRate, // _boostedGenerationRate
-      this.boostedThreshold, // _boostedThreshold
-      this.boostedDuration, // _boostedDuration
       this.maxCap, // _maxCap
     ]);
     await this.veJoe.transferOwnership(this.veJoeStaking.address);
@@ -95,20 +92,6 @@ describe("VeJoe Staking", function () {
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
-    it("should not allow owner to setBaseGenerationRate greater than boostedGenerationRate", async function () {
-      expect(await this.veJoeStaking.boostedGenerationRate()).to.be.equal(
-        this.boostedGenerationRate
-      );
-
-      await expect(
-        this.veJoeStaking
-          .connect(this.dev)
-          .setBaseGenerationRate(ethers.utils.parseEther("3"))
-      ).to.be.revertedWith(
-        "VeJoeStaking: expected new _baseGenerationRate to be less than boostedGenerationRate"
-      );
-    });
-
     it("should allow owner to setBaseGenerationRate", async function () {
       expect(await this.veJoeStaking.baseGenerationRate()).to.be.equal(
         this.baseGenerationRate
@@ -120,117 +103,6 @@ describe("VeJoe Staking", function () {
 
       expect(await this.veJoeStaking.baseGenerationRate()).to.be.equal(
         ethers.utils.parseEther("1.5")
-      );
-    });
-  });
-
-  describe("setBoostedGenerationRate", function () {
-    it("should not allow non-owner to setBoostedGenerationRate", async function () {
-      await expect(
-        this.veJoeStaking
-          .connect(this.alice)
-          .setBoostedGenerationRate(ethers.utils.parseEther("11"))
-      ).to.be.revertedWith("Ownable: caller is not the owner");
-    });
-
-    it("should not allow owner to setBoostedGenerationRate leq to baseGenerationRate", async function () {
-      expect(await this.veJoeStaking.baseGenerationRate()).to.be.equal(
-        this.baseGenerationRate
-      );
-
-      await expect(
-        this.veJoeStaking
-          .connect(this.dev)
-          .setBoostedGenerationRate(ethers.utils.parseEther("0.99"))
-      ).to.be.revertedWith(
-        "VeJoeStaking: expected new _boostedGenerationRate to be greater than baseGenerationRate"
-      );
-    });
-
-    it("should allow owner to setBoostedGenerationRate", async function () {
-      expect(await this.veJoeStaking.boostedGenerationRate()).to.be.equal(
-        this.boostedGenerationRate
-      );
-
-      await this.veJoeStaking
-        .connect(this.dev)
-        .setBoostedGenerationRate(ethers.utils.parseEther("3"));
-
-      expect(await this.veJoeStaking.boostedGenerationRate()).to.be.equal(
-        ethers.utils.parseEther("3")
-      );
-    });
-  });
-
-  describe("setBoostedThreshold", function () {
-    it("should not allow non-owner to setBoostedThreshold", async function () {
-      await expect(
-        this.veJoeStaking.connect(this.alice).setBoostedThreshold(10)
-      ).to.be.revertedWith("Ownable: caller is not the owner");
-    });
-
-    it("should not allow owner to setBoostedThreshold to 0", async function () {
-      await expect(
-        this.veJoeStaking.connect(this.dev).setBoostedThreshold(0)
-      ).to.be.revertedWith(
-        "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
-      );
-    });
-
-    it("should not allow owner to setBoostedThreshold greater than 100", async function () {
-      await expect(
-        this.veJoeStaking.connect(this.dev).setBoostedThreshold(101)
-      ).to.be.revertedWith(
-        "VeJoeStaking: expected _boostedThreshold to be > 0 and <= 100"
-      );
-    });
-
-    it("should allow owner to setBoostedThreshold", async function () {
-      expect(await this.veJoeStaking.boostedThreshold()).to.be.equal(
-        this.boostedThreshold
-      );
-
-      await this.veJoeStaking.connect(this.dev).setBoostedThreshold(10);
-
-      expect(await this.veJoeStaking.boostedThreshold()).to.be.equal(10);
-    });
-  });
-
-  describe("setBoostedDuration", function () {
-    it("should not allow non-owner to setBoostedDuration", async function () {
-      await expect(
-        this.veJoeStaking.connect(this.alice).setBoostedDuration(100)
-      ).to.be.revertedWith("Ownable: caller is not the owner");
-    });
-
-    it("should not allow owner to setBoostedDuration greater than 365 days", async function () {
-      const secondsInHour = 60 * 60;
-      const secondsInDay = secondsInHour * 24;
-      const secondsInYear = secondsInDay * 365;
-      await expect(
-        this.veJoeStaking
-          .connect(this.dev)
-          .setBoostedDuration(secondsInYear + 1)
-      ).to.be.revertedWith(
-        "VeJoeStaking: expected _boostedDuration to be <= 365 days"
-      );
-    });
-
-    it("should allow owner to setBoostedThreshold to upper limit", async function () {
-      const secondsInHour = 60 * 60;
-      const secondsInDay = secondsInHour * 24;
-      const secondsInYear = secondsInDay * 365;
-
-      expect(await this.veJoeStaking.boostedDuration()).to.be.equal(
-        this.boostedDuration
-      );
-
-      await this.veJoeStaking
-        .connect(this.dev)
-        .setBoostedDuration(secondsInYear);
-
-      expect(await this.veJoeStaking.boostedDuration()).to.be.equal(
-        secondsInYear
       );
     });
   });

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -3,7 +3,7 @@ const { ethers, network, upgrades } = require("hardhat");
 const { expect } = require("chai");
 const { describe } = require("mocha");
 
-describe("VeJoe Staking", function () {
+describe.only("VeJoe Staking", function () {
   before(async function () {
     this.VeJoeStakingCF = await ethers.getContractFactory("VeJoeStaking");
     this.VeJoeTokenCF = await ethers.getContractFactory("VeJoeToken");
@@ -87,12 +87,22 @@ describe("VeJoe Staking", function () {
   });
 
   describe("setVeJoePerSharePerSec", function () {
-    it("should not allow non-owner to setMaxCap", async function () {
+    it("should not allow non-owner to setVeJoePerSharePerSec", async function () {
       await expect(
         this.veJoeStaking
           .connect(this.alice)
           .setVeJoePerSharePerSec(ethers.utils.parseEther("1.5"))
       ).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("should not allow owner to set veJoePerSharePerSec greater than upper limit", async function () {
+      await expect(
+        this.veJoeStaking
+          .connect(this.dev)
+          .setVeJoePerSharePerSec(ethers.utils.parseUnits("1", 37))
+      ).to.be.revertedWith(
+        "VeJoeStaking: expected _veJoePerSharePerSec to be <= 1e36"
+      );
     });
 
     it("should allow owner to setVeJoePerSharePerSec", async function () {

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -24,13 +24,13 @@ describe("VeJoe Staking", function () {
     await this.joe.mint(this.bob.address, ethers.utils.parseEther("1000"));
     await this.joe.mint(this.carol.address, ethers.utils.parseEther("1000"));
 
-    this.veJoePerSec = ethers.utils.parseEther("1");
+    this.veJoePerSharePerSec = ethers.utils.parseEther("1");
     this.maxCap = 200;
 
     this.veJoeStaking = await upgrades.deployProxy(this.VeJoeStakingCF, [
       this.joe.address, // _joe
       this.veJoe.address, // _veJoe
-      this.veJoePerSec, // _veJoePerSec
+      this.veJoePerSharePerSec, // _veJoePerSharePerSec
       this.maxCap, // _maxCap
     ]);
     await this.veJoe.transferOwnership(this.veJoeStaking.address);
@@ -90,15 +90,15 @@ describe("VeJoe Staking", function () {
     });
 
     it("should allow owner to setVeJoePerSec", async function () {
-      expect(await this.veJoeStaking.veJoePerSec()).to.be.equal(
-        this.veJoePerSec
+      expect(await this.veJoeStaking.veJoePerSharePerSec()).to.be.equal(
+        this.veJoePerSharePerSec
       );
 
       await this.veJoeStaking
         .connect(this.dev)
         .setVeJoePerSec(ethers.utils.parseEther("1.5"));
 
-      expect(await this.veJoeStaking.veJoePerSec()).to.be.equal(
+      expect(await this.veJoeStaking.veJoePerSharePerSec()).to.be.equal(
         ethers.utils.parseEther("1.5")
       );
     });
@@ -296,7 +296,7 @@ describe("VeJoe Staking", function () {
       );
     });
 
-    it("should receive correct veJOE if veJoePerSec is updated multiple times", async function () {
+    it("should receive correct veJOE if veJoePerSharePerSec is updated multiple times", async function () {
       await this.veJoeStaking
         .connect(this.alice)
         .deposit(ethers.utils.parseEther("100"));
@@ -347,7 +347,7 @@ describe("VeJoe Staking", function () {
       expect(await this.veJoeStaking.lastRewardTimestamp()).to.be.equal(
         block.timestamp + 30
       );
-      // Increase should be `secondsElapsed * veJoePerSec * ACC_VEJOE_PER_SHARE_PRECISION`:
+      // Increase should be `secondsElapsed * veJoePerSharePerSec * ACC_VEJOE_PER_SHARE_PRECISION`:
       // = 30 * 1 * 1e18
       expect(await this.veJoeStaking.accVeJoePerShare()).to.be.equal(
         accVeJoePerShareBeforeUpdate.add(ethers.utils.parseEther("30"))

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -321,7 +321,7 @@ describe("VeJoe Staking", function () {
       expect(afterAliceUserInfo[3]).to.be.equal(0);
     });
 
-    it("should have speed up period extended after depositing speedUPThreshold and currently receiving speed up benefits", async function () {
+    it("should have speed up period extended after depositing speedUpThreshold and currently receiving speed up benefits", async function () {
       await this.veJoeStaking
         .connect(this.alice)
         .deposit(ethers.utils.parseEther("100"));

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -3,7 +3,7 @@ const { ethers, network, upgrades } = require("hardhat");
 const { expect } = require("chai");
 const { describe } = require("mocha");
 
-describe.only("VeJoe Staking", function () {
+describe("VeJoe Staking", function () {
   before(async function () {
     this.VeJoeStakingCF = await ethers.getContractFactory("VeJoeStaking");
     this.VeJoeTokenCF = await ethers.getContractFactory("VeJoeToken");

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -200,6 +200,10 @@ describe.only("VeJoe Staking", function () {
       expect(beforeAliceUserInfo[0]).to.be.equal(0);
       // rewardDebt
       expect(beforeAliceUserInfo[1]).to.be.equal(0);
+      // lastClaimTimestamp
+      expect(beforeAliceUserInfo[2]).to.be.equal(0);
+      // speedUpEndTimestamp
+      expect(beforeAliceUserInfo[3]).to.be.equal(0);
 
       // Check joe balance before deposit
       expect(await this.joe.balanceOf(this.alice.address)).to.be.equal(
@@ -222,6 +226,12 @@ describe.only("VeJoe Staking", function () {
       expect(afterAliceUserInfo[0]).to.be.equal(depositAmount);
       // debtReward
       expect(afterAliceUserInfo[1]).to.be.equal(0);
+      // lastClaimTimestamp
+      expect(afterAliceUserInfo[2]).to.be.equal(depositBlock.timestamp);
+      // speedUpEndTimestamp
+      expect(afterAliceUserInfo[3]).to.be.equal(
+        depositBlock.timestamp + this.speedUpDuration
+      );
     });
 
     it("should have correct updated user balance after deposit with non-zero balance", async function () {
@@ -255,9 +265,11 @@ describe.only("VeJoe Staking", function () {
         .deposit(ethers.utils.parseEther("1"));
 
       // Check veJoe balance after deposit
-      // Should have 100 * 30 = 3000 veJOE
+      // Should have sum of:
+      // baseVeJoe =  100 * 30 = 3000 veJOE
+      // speedUpVeJoe = 100 * 30 = 3000 veJOE
       expect(await this.veJoe.balanceOf(this.alice.address)).to.be.equal(
-        ethers.utils.parseEther("3000")
+        ethers.utils.parseEther("6000")
       );
     });
   });
@@ -305,7 +317,14 @@ describe.only("VeJoe Staking", function () {
       );
       // rewardDebt
       expect(beforeAliceUserInfo[1]).to.be.equal(
-        await this.veJoe.balanceOf(this.alice.address)
+        // Divide by 2 since half of it is from the speed up
+        (await this.veJoe.balanceOf(this.alice.address)).div(2)
+      );
+      // lastClaimTimestamp
+      expect(beforeAliceUserInfo[2]).to.be.equal(claimBlock.timestamp);
+      // speedUpEndTimestamp
+      expect(beforeAliceUserInfo[3]).to.be.equal(
+        depositBlock.timestamp + this.speedUpDuration
       );
 
       await this.veJoeStaking
@@ -323,6 +342,10 @@ describe.only("VeJoe Staking", function () {
       expect(afterAliceUserInfo[1]).to.be.equal(
         (await this.veJoeStaking.accVeJoePerShare()).mul(95)
       );
+      // lastClaimTimestamp
+      expect(afterAliceUserInfo[2]).to.be.equal(withdrawBlock.timestamp);
+      // speedUpEndTimestamp
+      expect(afterAliceUserInfo[3]).to.be.equal(0);
 
       // Check user token balances are updated correctly
       expect(await this.veJoe.balanceOf(this.alice.address)).to.be.equal(0);

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -3,7 +3,7 @@ const { ethers, network, upgrades } = require("hardhat");
 const { expect } = require("chai");
 const { describe } = require("mocha");
 
-describe.only("VeJoe Staking", function () {
+describe("VeJoe Staking", function () {
   before(async function () {
     this.VeJoeStakingCF = await ethers.getContractFactory("VeJoeStaking");
     this.VeJoeTokenCF = await ethers.getContractFactory("VeJoeToken");
@@ -141,45 +141,6 @@ describe.only("VeJoe Staking", function () {
       await this.veJoeStaking.connect(this.dev).setSpeedUpThreshold(10);
 
       expect(await this.veJoeStaking.speedUpThreshold()).to.be.equal(10);
-    });
-  });
-
-  describe("setSpeedUpDuration", function () {
-    it("should not allow non-owner to setSpeedUpDuration", async function () {
-      await expect(
-        this.veJoeStaking.connect(this.alice).setSpeedUpDuration(100)
-      ).to.be.revertedWith("Ownable: caller is not the owner");
-    });
-
-    it("should not allow owner to setSpeedUpDuration greater than 365 days", async function () {
-      const secondsInHour = 60 * 60;
-      const secondsInDay = secondsInHour * 24;
-      const secondsInYear = secondsInDay * 365;
-      await expect(
-        this.veJoeStaking
-          .connect(this.dev)
-          .setSpeedUpDuration(secondsInYear + 1)
-      ).to.be.revertedWith(
-        "VeJoeStaking: expected _speedUpDuration to be <= 365 days"
-      );
-    });
-
-    it("should allow owner to setSpeedUpDuration to upper limit", async function () {
-      const secondsInHour = 60 * 60;
-      const secondsInDay = secondsInHour * 24;
-      const secondsInYear = secondsInDay * 365;
-
-      expect(await this.veJoeStaking.speedUpDuration()).to.be.equal(
-        this.speedUpDuration
-      );
-
-      await this.veJoeStaking
-        .connect(this.dev)
-        .setSpeedUpDuration(secondsInYear);
-
-      expect(await this.veJoeStaking.speedUpDuration()).to.be.equal(
-        secondsInYear
-      );
     });
   });
 


### PR DESCRIPTION
This PR adds support for speed up to `veJoeStaking` as well as appropriate tests.

Some important things to note:
- User will receive speed up benefits if they are depositing for first time OR they deposit `speedUpThreshold` percentage of their current amount of staked JOE
- The speed up benefit is **on top** of the user's existing base veJoe accumulation
- The speed up generation rate is **constant and cannot be changed**