### PR TITLE
[VeJoeStaking] Update maxCap to be maxCapPct (scaled to 100)

### DIFF
--- a/contracts/VeJoeStaking.sol
+++ b/contracts/VeJoeStaking.sol
@@ -157,7 +157,7 @@ contract VeJoeStaking is Initializable, OwnableUpgradeable {
 
     /// @notice Set maxCapPct
     /// @param _maxCapPct The new maxCapPct
-    function setMaxCap(uint256 _maxCapPct) external onlyOwner {
+    function setMaxCapPct(uint256 _maxCapPct) external onlyOwner {
         require(_maxCapPct > maxCapPct, "VeJoeStaking: expected new _maxCapPct to be greater than existing maxCapPct");
         require(
             _maxCapPct != 0 && _maxCapPct <= upperLimitMaxCapPct,

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -55,7 +55,7 @@ describe("VeJoe Staking", function () {
   describe("setMaxCapPct", function () {
     it("should not allow non-owner to setMaxCapPct", async function () {
       await expect(
-        this.veJoeStaking.connect(this.alice).setMaxCapPct(200)
+        this.veJoeStaking.connect(this.alice).setMaxCapPct(this.maxCapPct + 1)
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -52,10 +52,10 @@ describe.only("VeJoe Staking", function () {
       .approve(this.veJoeStaking.address, ethers.utils.parseEther("100000"));
   });
 
-  describe("setMaxCap", function () {
-    it("should not allow non-owner to setMaxCap", async function () {
+  describe("setMaxCapPct", function () {
+    it("should not allow non-owner to setMaxCapPct", async function () {
       await expect(
-        this.veJoeStaking.connect(this.alice).setMaxCap(200)
+        this.veJoeStaking.connect(this.alice).setMaxCapPct(200)
       ).to.be.revertedWith("Ownable: caller is not the owner");
     });
 
@@ -63,7 +63,7 @@ describe.only("VeJoe Staking", function () {
       expect(await this.veJoeStaking.maxCapPct()).to.be.equal(this.maxCapPct);
 
       await expect(
-        this.veJoeStaking.connect(this.dev).setMaxCap(99)
+        this.veJoeStaking.connect(this.dev).setMaxCapPct(this.maxCapPct - 1)
       ).to.be.revertedWith(
         "VeJoeStaking: expected new _maxCapPct to be greater than existing maxCapPct"
       );
@@ -71,16 +71,18 @@ describe.only("VeJoe Staking", function () {
 
     it("should not allow owner to set maxCapPct greater than upper limit", async function () {
       await expect(
-        this.veJoeStaking.connect(this.dev).setMaxCap(100001)
+        this.veJoeStaking.connect(this.dev).setMaxCapPct(10000001)
       ).to.be.revertedWith(
-        "VeJoeStaking: expected new _maxCapPct to be non-zero and <= 100000"
+        "VeJoeStaking: expected new _maxCapPct to be non-zero and <= 10000000"
       );
     });
 
-    it("should allow owner to setMaxCap", async function () {
+    it("should allow owner to setMaxCapPct", async function () {
       expect(await this.veJoeStaking.maxCapPct()).to.be.equal(this.maxCapPct);
 
-      await this.veJoeStaking.connect(this.dev).setMaxCap(this.maxCapPct + 100);
+      await this.veJoeStaking
+        .connect(this.dev)
+        .setMaxCapPct(this.maxCapPct + 100);
 
       expect(await this.veJoeStaking.maxCapPct()).to.be.equal(
         this.maxCapPct + 100

--- a/test/VeJoeStaking.test.js
+++ b/test/VeJoeStaking.test.js
@@ -3,7 +3,7 @@ const { ethers, network, upgrades } = require("hardhat");
 const { expect } = require("chai");
 const { describe } = require("mocha");
 
-describe.only("VeJoe Staking", function () {
+describe("VeJoe Staking", function () {
   before(async function () {
     this.VeJoeStakingCF = await ethers.getContractFactory("VeJoeStaking");
     this.VeJoeTokenCF = await ethers.getContractFactory("VeJoeToken");


### PR DESCRIPTION
Currently, `VeJoeStaking` has a notion of `maxCap` which is a whole number that represents the max veJOE a user can have, e.g. if `maxCap = 100`, `maxVeJoeBalance = user.balance * 100`. However, I was looking at the `Staking V2 Contract Specs` and noticed max cap was being referred to as:

 `MAX_CAP_PCT = Max limit of veJOE as percentage points of JOE balance`

This means that we should allow setting a user's max `veJOE` to be `1.5X` their current staked `JOE`, which you wouldn't be able to currently do. This PR updates `VeJoeStaking` to handle this