### PR TITLE
[Ackee Audit][H4] Override renounceOwnership in VeJoeToken

### DIFF
--- a/contracts/VeJoeToken.sol
+++ b/contracts/VeJoeToken.sol
@@ -43,4 +43,8 @@ contract VeJoeToken is VeERC20("VeJoeToken", "veJOE"), Ownable {
             boostedMasterChef.updateBoost(_account, _newBalance);
         }
     }
+
+    function renounceOwnership() public override onlyOwner {
+        revert("VeJoeToken: Cannot renounce, can only transfer ownership");
+    }
 }


### PR DESCRIPTION
H4: Renounce ownership

**Description**
For staking purposes, owner must be set to VeJoeStaking contract address. Therefore, renounceOwnership is not potentially useful.

**Exploit scenario**
owner is renounced, and thus users of VeJoeStaking can not claim their veJOE or JOE tokens.

**Recommendation**
Override the renounceOwnership method to disable this unwanted feature.